### PR TITLE
decltype(auto) mangling

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -4346,7 +4346,8 @@ Builtin types are represented by single-letter codes:
                  ::= Dh # IEEE 754r half-precision floating point (16 bits)
                  ::= Di # char32_t
                  ::= Ds # char16_t
-                 ::= Da # auto (in dependent new-expressions)
+                 ::= Da # auto
+                 ::= Dc # decltype(auto)
                  ::= Dn # std::nullptr_t (i.e., decltype(nullptr))
 		 ::= u &lt;<a href="#mangle.source-name">source-name</a>&gt;	# vendor extended type
 </pre></font></code>


### PR DESCRIPTION
This change adds mangling for decltype(auto), introduced by N3638.
