### PR TITLE
Specified that mangled name grammar productions that begin with the '$' character are reserved for private implementation use.

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -4020,6 +4020,10 @@ we use <code>Ret?</code> for an unknown function return type
 or <code>Type?</code> for an unknown data type.
 
 <p>
+Grammar productions beginning with '$' are reserved for private implementation
+use.  Names produced using such extensions are inherently non-portable.
+
+<p>
 <a name="mangling-structure">
 <h4><a href="#mangling-structure"> 5.1.2 General Structure </a></h4>
 


### PR DESCRIPTION
Addresses issue #11.