### PR TITLE
Mangling for C++1z structured binding declarations

### DIFF
--- a/abi-mangling.html
+++ b/abi-mangling.html
@@ -51,6 +51,7 @@ C++ ABI for IA-64: Mangling
 <tr><td>oper</td> <td>d</td> <td> V </td> <td> Operator /= </td> </tr>
 <tr><td>type</td> <td>D</td> <td> p </td> <td> pack expansion of (C++0x) </td> </tr>
 <tr><td>type</td> <td>D</td> <td> t </td> <td> decltype of an id-expression or class member access (C++0x) </td> </tr>
+<tr><td>obj </td> <td>D</td> <td> C </td> <td> structured binding declaration (C++1z) </td> </tr>
 <tr><td>type</td> <td>D</td> <td> T </td> <td> decltype of an expression (C++0x) </td> </tr>
 <tr><td>obj </td> <td>D</td> <td> 0 </td> <td> Deleting destructor</td> </tr>
 <tr><td>obj </td> <td>D</td> <td> 1 </td> <td> Complete object (in-charge) destructor</td> </tr>

--- a/abi.html
+++ b/abi.html
@@ -4144,6 +4144,7 @@ qualifiers could be inferred from the substitution target.
                        ::= &lt;<a href="#mangle.ctor-dtor-name">ctor-dtor-name</a>&gt;  
                        ::= &lt;<a href="#mangle.source-name">source-name</a>&gt;   
                        ::= &lt;<a href="#mangle.unnamed-type-name">unnamed-type-name</a>&gt;   
+                       ::= DC &lt;<a href="#mangle.source-name">source-name</a>&gt;+ E      # structured binding declaration
 
     &lt;<a name="mangle.source-name">source-name</a>&gt; ::= &lt;<i>positive length</i> <a href="#mangle.number">number</a>&gt; &lt;<a href="#mangle.identifier">identifier</a>&gt;
     &lt;<a name="mangle.identifier">identifier</a>&gt; ::= &lt;<i>unqualified source code identifier</i>>


### PR DESCRIPTION
Formerly known as "decomposition declarations". As discussed on cxx-abi-dev@ in thread starting 2016-08-12.