### PR TITLE
Add move constructors to the invisible reference rule.

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -2667,8 +2667,9 @@ There are, however, some special cases.
 <ol type="1">
  <li>
   <p>
-   In the special case where the parameter type has a non-trivial copy
-   constructor or destructor, the caller must allocate space for a
+   In the special case where the parameter type has a non-trivial copy or move
+   constructor or destructor, or all copy and move constructors are deleted,
+   the caller must allocate space for a
    temporary copy, and pass the resulting copy by reference (below).
    Specifically,
   </p>


### PR DESCRIPTION
We've agreed on this several times over the years (in the thread "Transfer modes for parameters and return values"), but the document still hasn't been updated.  In that thread Richard proposed the wording "[Pass an object of class type by value if] every copy constructor and move constructor is deleted or trivial and at least one of them is not deleted, and the destructor is trivial", but that requires reversing the sense of the paragraph; I believe that my wording below has the same effect.