### PR TITLE
Corrected some references to the <template-param> grammar production that were spelled as <template-parameter>.

### DIFF
--- a/abi-layout.html
+++ b/abi-layout.html
@@ -2954,7 +2954,7 @@ Function types are composed from their parameter types and possibly the
 result type.
 Except at the outer level type of an &lt;encoding>,
 or in the &lt;encoding> of an otherwise delimited external name in a
-&lt;template-parameter> or &lt;local-name> function encoding,
+&lt;template-param> or &lt;local-name> function encoding,
 these types are delimited by an "F..E" pair.
 For purposes of substitution
 (see <a href=#mangling-compression>Compression</a> below),

--- a/abi.html
+++ b/abi.html
@@ -4567,7 +4567,7 @@ Function types are composed from their parameter types and possibly the
 result type.
 Except at the outer level type of an &lt;<a href="#mangle.encoding">encoding</a>&gt;,
 or in the &lt;<a href="#mangle.encoding">encoding</a>&gt; of an otherwise delimited external name in a
-&lt;<a href="#mangle.template-parameter">template-parameter</a>&gt; or &lt;<a href="#mangle.local-name">local-name</a>&gt; function encoding,
+&lt;<a href="#mangle.template-param">template-param</a>&gt; or &lt;<a href="#mangle.local-name">local-name</a>&gt; function encoding,
 these types are delimited by an "F..E" pair.
 For purposes of substitution
 (see <a href=#mangling-compression>Compression</a> below),
@@ -5402,7 +5402,7 @@ This is never ambiguous with a lambda parameter whose type is an
 enclosing template type parameter, because lambdas are never mangled
 in a dependent context (they are forbidden from appearing in function
 signatures).  A &lt;<a
-href="#mangle.template-parameter">template-param</a>&gt; in a &lt;<a
+href="#mangle.template-param">template-param</a>&gt; in a &lt;<a
 href="#mangle.lambda-sig">lambda-sig</a>&gt; can only ever refer to a
 template parameter of a generic lambda.
 


### PR DESCRIPTION
This also corrects associated broken links.