### PR TITLE
Record the non-standard mangling of the GNU address_space attribute

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -4591,7 +4591,7 @@ Vendors who define extended type qualifiers (e.g. <code>_near</code> and
 <code>_far</code> for pointers) shall encode them as a 'U' prefix, followed
 by the name in &lt;length,ID&gt; form, followed optionally by any arguments
 to the qualifier.  It is recommended that the encoded name be the
-preferred name used in source code.
+preferred name used in source code; known exceptions are <a href="#mangling-vendor-qualifier-exceptions">listed below</a>.
 
 <p>
 In cases where multiple order-insensitive qualifiers are present,
@@ -4628,6 +4628,26 @@ if and only if it also treats it as a distinguishing attribute for
 overloading purposes.
 This ABI does not specify that choice.
 </i>
+
+<a name="mangling-vendor-qualifier-exceptions">
+<h6>Known exceptions to the extended qualifier rules</h6>
+
+<ul compact>
+<li>
+The GNU <code>address_space(N)</code> qualifier is mangled using the
+name <code>AS</code>.  For historical reasons, if the argument expression
+is not instantiation-dependent, its value is incorporated directly into
+the &lt;<a href="#mangle.source-name">source-name</a>&gt; of the qualifier;
+otherwise it is encoded as a qualifier argument.
+
+<p>
+For example, <code>int __attribute__((address_space(3))) *</code> is
+encoded as <code>PU3AS3i</code>, but
+<code>int __attribute__((address_space(K))) *</code> (given that
+<code>K</code> is a dependent reference to the first template parameter) is
+encoded as <code>PU2ASIT_Ei</code>.
+
+</ul>
 
 <a name="mangling-builtin">
 <h5><a href="#mangling-builtin">5.1.5.2 Builtin types</a></h5>


### PR DESCRIPTION
This mangling comes from Clang, historical warts and all; GCC does not currently support this attribute in C++.