### PR TITLE
Incorporate exception-specification into mangling and type_info

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -2416,6 +2416,7 @@ It adds two data members:
 	    __incomplete_mask = 0x8,
 	    __incomplete_class_mask = 0x10,
 	    __transaction_safe_mask = 0x20
+	    __noexcept_mask = 0x40
 	  };
       };
 
@@ -4729,6 +4730,13 @@ function type as described below.
 </p>
 
 <p>
+When an exception-specification (i.e., "noexcept", "noexcept(expression)", or
+"throw(type(s))") is part of the function type, it is mangled according to
+<code>&lt;<a href="#mangle.exception-spec">exception-spec</a>&gt;</code> as
+described below.
+</p>
+
+<p>
 A transaction-safe function type is encoded with a "Dx" before the "F".  This
 affects only type mangling; a transaction-safe function has the same mangling
 as a non-transaction-safe function.
@@ -4742,9 +4750,12 @@ implementations which distinguish between function types with "C" and
 </p>
 
 <pre><font color=blue><code>
-  &lt;function-type&gt; ::= [&lt;<a href="#mangle.CV-qualifiers">CV-qualifiers</a>&gt;] [Dx] F [Y] &lt;<a href="#mangle.bare-function-type">bare-function-type</a>&gt; [&lt;<a href="#mangle.ref-qualifier">ref-qualifier</a>&gt;] E
+  &lt;function-type&gt; ::= [&lt;<a href="#mangle.CV-qualifiers">CV-qualifiers</a>&gt;] [&lt;<a href="#mangle.exception-spec">exception-spec</a>&gt;] [Dx] F [Y] &lt;<a href="#mangle.bare-function-type">bare-function-type</a>&gt; [&lt;<a href="#mangle.ref-qualifier">ref-qualifier</a>&gt;] E
   &lt;<a name="mangle.bare-function-type">bare-function-type</a>&gt; ::= &lt;<i>signature</i> <a href="#mangle.type">type</a>&gt;+
 	# types are possible return type, then parameter types
+  &lt;<a name="mangle.exception-spec">exception-spec&gt; ::= Do                # non-throwing exception-specification
+                   ::= DO &lt;<a href="#mangle.expression">expression</a>&gt; E # computed (instantiation-dependent) noexcept
+                   ::= Dw &lt;<a href="#mangle.type">type</a>&gt;+ E      # throw (type(s))
 
 </pre></font></code>
 

--- a/abi.html
+++ b/abi.html
@@ -4740,6 +4740,11 @@ function type as described below.
 </p>
 
 <p>
+When an exception-specification (i.e., <code>noexcept</code>,
+<code>noexcept(expression)</code>, or <code>throw(type(s))</code>) is part of
+the function type, it is mangled according to
+<code>&lt;<a href="#mangle.exception-spec">exception-spec</a>&gt;</code> as
+described below.
 A non-instantiation-dependent, potentially-throwing exception specification is
 not mangled.
 </p>

--- a/abi.html
+++ b/abi.html
@@ -4740,12 +4740,6 @@ function type as described below.
 </p>
 
 <p>
-When an exception-specification (i.e., <code>noexcept</code>,
-<code>noexcept(expression)</code>, or <code>throw(type(s))</code>) is part of
-the function type, it is mangled according to
-<code>&lt;<a href="#mangle.exception-spec">exception-spec</a>&gt;</code> as
-described below.
-<code>throw()</code> should be mangled as Do, and <code>throw(anything else)</code> (as an extension) should be mangled as an empty <code>&lt;<a href="#mangle.exception-spec">exception-spec</a>&gt;</code> if it's not instantiation-dependent.
 A non-instantiation-dependent, potentially-throwing exception specification is
 not mangled.
 </p>

--- a/abi.html
+++ b/abi.html
@@ -2428,8 +2428,14 @@ It adds two data members:
   <li> <code>__flags</code> is a flag word describing the
       cv-qualification and other attributes of the type pointed to
       (e.g., "int volatile*" should have the
-      "volatile" bit set in that word);
-      and
+      "volatile" bit set in that word).
+      For pointer to function and pointer-to-member-function types,
+      <code>__flags</code> is also used to indicate a "qualification" of sorts
+      for the pointed-to (member) function type.  That is the case for
+      <code>__transaction_safe_mask</code> and <code>__noexcept_mask</code>
+      where <code>__pointee</code> is a pointer to the "unqualified" version of
+      the function type (e.g., one without the exception specification in the
+      case of <code>__noexcept_mask</code>).
   <p>
   <li> <code>__pointee</code> is a pointer to the
       <code>std::type_info</code> derivation for the unqualified type
@@ -2450,6 +2456,10 @@ and may be referenced using the flags defined in the
 <li> 0x8: <code>__pointee</code> type is incomplete
 <li> 0x10: class containing <code>__pointee</code>
 	  is incomplete (in pointer to member)
+<li> 0x20: <code>__pointee</code> type is function type without the
+	  transaction-safe indication
+<li> 0x40: <code>__pointee</code> type is function type without the
+	  exception specification
 </ul>
 
 <p>
@@ -4730,10 +4740,14 @@ function type as described below.
 </p>
 
 <p>
-When an exception-specification (i.e., "noexcept", "noexcept(expression)", or
-"throw(type(s))") is part of the function type, it is mangled according to
+When an exception-specification (i.e., <code>noexcept</code>,
+<code>noexcept(expression)</code>, or <code>throw(type(s))</code>) is part of
+the function type, it is mangled according to
 <code>&lt;<a href="#mangle.exception-spec">exception-spec</a>&gt;</code> as
 described below.
+<code>throw()</code> should be mangled as Do, and <code>throw(anything else)</code> (as an extension) should be mangled as an empty <code>&lt;<a href="#mangle.exception-spec">exception-spec</a>&gt;</code> if it's not instantiation-dependent.
+A non-instantiation-dependent, potentially-throwing exception specification is
+not mangled.
 </p>
 
 <p>
@@ -4753,9 +4767,9 @@ implementations which distinguish between function types with "C" and
   &lt;function-type&gt; ::= [&lt;<a href="#mangle.CV-qualifiers">CV-qualifiers</a>&gt;] [&lt;<a href="#mangle.exception-spec">exception-spec</a>&gt;] [Dx] F [Y] &lt;<a href="#mangle.bare-function-type">bare-function-type</a>&gt; [&lt;<a href="#mangle.ref-qualifier">ref-qualifier</a>&gt;] E
   &lt;<a name="mangle.bare-function-type">bare-function-type</a>&gt; ::= &lt;<i>signature</i> <a href="#mangle.type">type</a>&gt;+
 	# types are possible return type, then parameter types
-  &lt;<a name="mangle.exception-spec">exception-spec&gt; ::= Do                # non-throwing exception-specification
+  &lt;<a name="mangle.exception-spec">exception-spec&gt; ::= Do                # non-throwing exception-specification (e.g., noexcept, throw())
                    ::= DO &lt;<a href="#mangle.expression">expression</a>&gt; E # computed (instantiation-dependent) noexcept
-                   ::= Dw &lt;<a href="#mangle.type">type</a>&gt;+ E      # throw (type(s))
+                   ::= Dw &lt;<a href="#mangle.type">type</a>&gt;+ E      # dynamic exception specification with instantiation-dependent types
 
 </pre></font></code>
 


### PR DESCRIPTION
The discussions relating to incorporating exception-specifications into function types (starting with http://sourcerytools.com/pipermail/cxx-abi-dev/2016-October/002979.html) appear to never have been merged into the IA-64 specification.

I've gone through that thread and I *think* this pull request represents what was decided though I should mention a couple of items:

- I made an editorial change for "Dw <types>+ E" rather than "Dw <types>* E" because there should always be at least one type for this case.
- I didn't include __noreturn_mask because there seemed to be no consensus for it.

Let me know if I've misrepresented anything.