### PR TITLE
Include inline variables and variable templates in the list of contexts in which lambda closure types are mangled.

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -5460,7 +5460,7 @@ See additional examples in the
 <h4><a href="#closure-types">5.1.8 Closure Types (Lambdas)</a></h4>
 
 <p>
-A C++0x lambda expression introduces a unique class type called
+A lambda expression introduces a unique class type called
 <i>closure type</i>.  In some contexts, such closure types are
 unique to the translation unit: This ABI therefore does not specify an
 encoding for such cases (but an implementation must ensure that any
@@ -5476,10 +5476,9 @@ In the following contexts, however, the one-definition rule requires
 closure types in different translation units to "correspond":
 <ul>
 <li>default arguments appearing in class definitions</li>
-<li>the in-class initializers of class members (a C++0x feature)</li>
-<li>the bodies of inline functions</li>
-<li>the bodies of non-exported nonspecialized template functions</li>
-<li>the initializers of nonspecialized static members of template classes</li> 
+<li>default member initializers</li>
+<li>the bodies of inline or templated functions</li>
+<li>the initializers of inline or templated variables</li>
 </ul>
 
 In all these contexts, the encoding of the closure types builds on an

--- a/abi.html
+++ b/abi.html
@@ -5547,10 +5547,14 @@ not affect its encoding.
 
 <a name="mangle.data-member-prefix"><p>
 If the context of a closure type is an initializer for a class
-member (static or nonstatic), it is encoded in a qualified name with a
+member (static or nonstatic), inline variable, or variable template,
+it is encoded in a qualified name with a
 final <code>&lt;<a href="#mangle.prefix">prefix</a>&gt;</code> of the form:
-<code><pre><font color=blue>  &lt;data-member-prefix&gt; := &lt;<i>member</i> <a href="#mangle.source-name">source-name</a>&gt; M
+<code><pre><font color=blue>  &lt;data-member-prefix&gt; := &lt;<i>member</i> <a href="#mangle.source-name">source-name</a>&gt; [&lt;<a href="#mangle.template-args">template-args</a>&gt;] M
 </font></pre></code>
+where the <code>&lt;<a href="#mangle.template-args">template-args</a>&gt;</code>
+is present for a closure type within a variable template specialization
+and absent otherwise.
 For example:
 <code><pre>
 	template&lt;typename T> struct S {


### PR DESCRIPTION
Update to more modern terminology where appropriate and drop anachronisms.