### PR TITLE
Add vector type mangling (as discussed on the IA-64 reflector in 2009)

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -4698,6 +4698,7 @@ Builtin types are represented by single-letter codes:
                  ::= Da # auto
                  ::= Dc # decltype(auto)
                  ::= Dn # std::nullptr_t (i.e., decltype(nullptr))
+                 ::= Dv &lt;<i>elements</i> <a href="#mangle.number">number</a>&gt; _ &lt;<i>element</i> <a href="#mangle.type">type</a>&gt; # vector type
 		 ::= u &lt;<a href="#mangle.source-name">source-name</a>&gt;	# vendor extended type
 </pre></font></code>
 


### PR DESCRIPTION
This adds Dv<number>_<type> mangling for vector types (as discussed on the old IA-64 ABI reflector in November 2009).