### PR TITLE
Fix description of empty classes to handle anonymous bit-fields of no…

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -163,7 +163,8 @@ virtual base classes).
 <p>
 <dt> <i>empty class</i> </dt>
 <dd>
-A class with no non-static data members other than zero-width bitfields,
+A class with no non-static data members,
+no unnamed bit-fields other than zero-width bit-fields,
 no virtual functions, no virtual base classes,
 and no non-empty non-virtual proper base classes.
 
@@ -231,7 +232,7 @@ Y.
 A class that contains a virtual pointer, but no other data except
 (possibly) virtual bases.  In particular, it:
 <ul>
-<li> has no non-static data members other than zero-width bitfields,
+<li> has no non-static data members and no non-zero-width unnamed bit-fields,
 <li> has no direct base classes that are not either empty, nearly empty,
      or virtual,
 <li> has at most one non-virtual, nearly empty direct base class, and
@@ -269,8 +270,8 @@ this has the effect of performing a trivial copy of the type.
 In general, a type is considered a POD for the purposes of layout if
 it is a POD type (in the sense of ISO C++ [basic.types]).  However, a
 POD-struct or POD-union (in the sense of ISO C++ [class]) with a
-bitfield member whose declared width is wider than the declared type
-of the bitfield is not a POD for the purpose of layout.  Similarly, an
+bit-field whose declared width is wider than the declared type
+of the bit-field is not a POD for the purpose of layout.  Similarly, an
 array type is not a POD for the purpose of layout if the element type
 of the array is not a POD for the purpose of layout.  Where references
 to the ISO C++ are made in this paragraph, the Technical Corrigendum 1
@@ -779,13 +780,13 @@ is not necessary.
 <p>
 For each data component D (first the primary base of C, if any, then
 the non-primary, non-virtual direct base classes in declaration order,
-then the non-static data members and unnamed bitfields in declaration
+then the non-static data members and unnamed bit-fields in declaration
 order), allocate as follows:
 
   <ol type=1>
 
   <p>
-  <li> If D is a (possibly unnamed) bitfield whose declared type is 
+  <li> If D is a (possibly unnamed) bit-field whose declared type is
        <code>T</code> and whose declared width is <code>n</code> bits:
 
        <p>
@@ -796,13 +797,13 @@ order), allocate as follows:
        <p>
        <li>
        If <code>sizeof(T)*8 >= n</code>,
-       the bitfield is allocated as required by the underlying C psABI,
-       subject to the constraint that a bitfield is never placed in the 
+       the bit-field is allocated as required by the underlying C psABI,
+       subject to the constraint that a bit-field is never placed in the
        tail padding of a base class of C.
 
        <p>
        If dsize(C) > 0, and the byte at offset dsize(C) - 1 is
-       partially filled by a bitfield, and that bitfield is also a
+       partially filled by a bit-field, and that bit-field is also a
        data member declared in C (but not in one of C's proper base
        classes), the next available bits are the unfilled bits at
        offset dsize(C) - 1.  Otherwise, the next available bits are at
@@ -816,10 +817,10 @@ order), allocate as follows:
        If <code>sizeof(T)*8 < n</code>,
        let T' be the largest integral POD type with
        <code>sizeof(T')*8 <= n</code>.
-       The bitfield is allocated starting at the next offset aligned
+       The bit-field is allocated starting at the next offset aligned
        appropriately for T', with length n bits.
        The first <code>sizeof(T)*8</code> bits are used to hold the
-       value of the bitfield,
+       value of the bit-field,
        followed by <code>n - sizeof(T)*8</code> bits of padding.
 	<p>
 	Update align(C) to max (align(C), align(T')).
@@ -828,7 +829,7 @@ order), allocate as follows:
        <p>
        In either case,
        update dsize(C) to include the last byte
-       containing (part of) the bitfield,
+       containing (part of) the bit-field,
        and update sizeof(C) to max(sizeof(C),dsize(C)).
 
   <p>
@@ -6084,7 +6085,7 @@ unwind table location.
   Reverse treatment of ambiguous arguments to __cxa_demangle (3.4).</p>
 
 <p class="revision"><span class="date">[041118]</span>
-  Clarify the layout of bitfields.</p>
+  Clarify the layout of bit-fields.</p>
 
 <p class="revision"><span class="date">[041025]</span>
   Indicate that the TC1 definition of POD is intended in the section
@@ -6327,7 +6328,7 @@ unwind table location.
   Add thunk definition.
   Revise inheritance graph order definition.
   Fix member function pointer description (no division by two).
-  Move bitfield allocation description (much modified)
+  Move bit-field allocation description (much modified)
   to the non-virtual-base allocation description.
   Replace virtual function calling convention description.</p>
 
@@ -6335,12 +6336,12 @@ unwind table location.
   Add thunk definition.
   Revise inheritance graph order definition.
   Fix member function pointer description (no division by two).
-  Move bitfield allocation description (much modified)
+  Move bit-field allocation description (much modified)
   to the non-virtual-base allocation description.
   Replace virtual function calling convention description.</p>
 
 <p class="revision"><span class="date">[000217]</span>
-  Add excess-size bitfield specification.
+  Add excess-size bit-field specification.
   Add namespace/header section.
   Touch up array new cookies.
   Remove construction vtable example to new file.


### PR DESCRIPTION
…nzero length.

Anonymous bit-fields are not non-static data members, so the definition of "empty class" disregarded them. Clang follows the letter of this rule; GCC and ICC follow the intent, which is that anonymous bit-fields of non-zero length render a class object non-empty.

The C++ standard has the same bug, which is currently in the process of being corrected by http://wg21.link/lwg2358.