### PR TITLE
Add 'ss' as encoding for operator '<=>'.

### DIFF
--- a/abi-mangling.html
+++ b/abi-mangling.html
@@ -125,6 +125,7 @@ C++ ABI for IA-64: Mangling
 <tr><td>name</td> <td>s</td> <td></td> <td> local string prefix </td> </tr>
 <tr><td>oper</td> <td>s</td> <td> p </td> <td> Expression pack expansion operator</td> </tr>
 <tr><td>oper</td> <td>s</td> <td> r </td> <td> Scope resolution operator </td> </tr>
+<tr><td>oper</td> <td>s</td> <td> s </td> <td> Operator &lt;=> (C++2a "spaceship") </td> </tr>
 <tr><td>oper</td> <td>s</td> <td> t </td> <td> Operator sizeof (a type)</td> </tr>
 <tr><td>oper</td> <td>s</td> <td> z </td> <td> Operator sizeof (an expression)</td> </tr>
 <tr><td>oper</td> <td>s</td> <td> Z </td> <td> Operator sizeof (a pack expansion)</td> </tr>

--- a/abi.html
+++ b/abi.html
@@ -4362,6 +4362,7 @@ the first of which is lowercase.
 		  ::= gt	# >             
 		  ::= le	# <=            
 		  ::= ge	# >=            
+		  ::= ss	# &lt;=>           
 		  ::= nt	# !             
 		  ::= aa	# &&            
 		  ::= oo	# ||            


### PR DESCRIPTION
Fixes #43