### PR TITLE
Provide layout rules for non-POD unions (N2544).

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -792,10 +792,10 @@ is not necessary.
 <p>
 <li> <h5> Allocation of Members Other Than Virtual Bases </h5>
 <p>
-For each data component D (first the primary base of C, if any, then
+Each data component D (first the primary base of C, if any, then
 the non-primary, non-virtual direct base classes in declaration order,
 then the non-static data members and unnamed bit-fields in declaration
-order), allocate as follows:
+order) is laid out in order. If C is not a union, allocate as follows:
 
   <ol type=1>
 
@@ -912,6 +912,10 @@ order), allocate as follows:
 	a data member.  Since D is empty, no update of dsize(C) is needed.
 
   </ol>
+
+  <p>
+  If C is a union, D is placed at offset 0, but dsize(C) and sizeof(C)
+  are updated as for a non-union member, as described above.
 
   <p>
   After all such components have been allocated, set nvalign(C) =


### PR DESCRIPTION
The layout rules do not anticipate the possibility of a union not being a POD for the purpose of layout. Extend the rules to cover this situation a the way that appears to match current implementation consensus.