### PR TITLE
Delete duplicate <name> mangling rule

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -5750,17 +5750,9 @@ the following catalog of abbreviations of the form "Sx" are used:
 </pre></font></code>
 
 <p>
-The abbreviation St is always an initial qualifier,
-i.e. appearing as the first element of a compound name.
-It does not require N...E delimiters unless
+Note that the abbreviation St does not require N...E delimiters unless
 either followed by more than one additional composite name component,
 or preceded by CV-qualifiers or a ref-qualifier for a member function.
-This adds the case:
-<pre><font color=blue><code>
-   &lt;<a name="mangle.name">name</a>&gt; ::= St &lt;<a href="#mangle.unqualified-name">unqualified-name</a>&gt; # ::std::
-
-</pre></font></code>
-
 For example:
 <code><pre>
    "_ZSt5state": ::std::state


### PR DESCRIPTION
```
   <name> ::= St <unqualified-name> # ::std::
```

is already covered by

```
   <name> ::= <unscoped-name>
   <unscoped-name> ::= St <unqualified-name>   # ::std::
```