### PR TITLE
Fix underscore typo in special_name

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -4588,7 +4588,7 @@ mangling, used for calls from a non-transaction context, and another entry
 point used for calls during a transaction.  The mangled name of the transaction entry point is the normal mangling prefixed with GTt.
 
 <pre><font color=blue><code>
-  &lt;special_name> ::= GTt &lt;encoding>
+  &lt;special-name&gt; ::= GTt &lt;encoding&gt;
 </pre></font></code>
 
 <a name="mangling-type">


### PR DESCRIPTION
Other `<special-name>` terms are written with a hyphen.