### PR TITLE
Add compression mangling for versioning namespaces in std

### DIFF
--- a/abi-layout.html
+++ b/abi-layout.html
@@ -3346,7 +3346,27 @@ the following catalog of abbreviations of the form "Sx" are used:
    &lt;substitution> ::= Si # ::std::basic_istream&lt;char,  std::char_traits&lt;char> >
    &lt;substitution> ::= So # ::std::basic_ostream&lt;char,  std::char_traits&lt;char> >
    &lt;substitution> ::= Sd # ::std::basic_iostream&lt;char, std::char_traits&lt;char> >
+</pre></font></code>
 
+To account for versioned standard library namespaces, the following substitutions
+are defined, where &lt;inline-ns> is the numeric part of a namespace name matching
+__[0-9]+, except __1 for which there is no substitution.
+
+<p><i>
+Note that versioning namespaces matching __1 are not compressed because that would
+constitute an ABI break for existing implementations, which already use that scheme.
+</i></p>
+
+<pre><font color=blue><code>
+   &lt;substitution> ::= Stv&lt;inline-ns>v # ::std::__[0-9]+
+   &lt;substitution> ::= Sav&lt;inline-ns>v # ::std::__[0-9]+::allocator
+   &lt;substitution> ::= Sbv&lt;inline-ns>v # ::std::__[0-9]+::basic_string
+   &lt;substitution> ::= Ssv&lt;inline-ns>v # ::std::__[0-9]+::basic_string &lt; char,
+                                                                        ::std::__[0-9]+::char_traits&lt;char>,
+                                                                        ::std::__[0-9]+::allocator&lt;char> >
+   &lt;substitution> ::= Siv&lt;inline-ns>v # ::std::__[0-9]+::basic_istream&lt;char,  std::__[0-9]+::char_traits&lt;char> >
+   &lt;substitution> ::= Sov&lt;inline-ns>v # ::std::__[0-9]+::basic_ostream&lt;char,  std::__[0-9]+::char_traits&lt;char> >
+   &lt;substitution> ::= Sdv&lt;inline-ns>v # ::std::__[0-9]+::basic_iostream&lt;char, std::__[0-9]+::char_traits&lt;char> >
 </pre></font></code>
 
 <p>


### PR DESCRIPTION
This is a strawman proposal to add substitutions for inline namespaces (fixing #42). I've never touched the Itanium ABI before so this is most likely wrong and/or too naive, but this is at least something concrete to get us started with.

A couple of notes on my approach:

- We don't compress `std::__1`, because that's already in use.
- I delimit with `v` on both sides to avoid clashing with things like `St3`. There may be a better way of doing this.

@zygoloid In #42, you say:

> I don't have a concrete suggestion yet; whatever we pick, we'll presumably want the `std::<inline namespace>` part to itself be substitutable, which makes this a bit awkward to fit into the existing scheme.

Can you explain what you mean by that? I suspect this will throw my approach down the drain (but that's fine).

Fixes #42
