### PR TITLE
Add 'aw' as encoding for operator 'co_await'

### DIFF
--- a/abi-mangling.html
+++ b/abi-mangling.html
@@ -34,6 +34,7 @@ C++ ABI for IA-64: Mangling
 <tr><td>oper</td> <td>a</td> <td> N </td> <td> Operator &= </td> </tr>
 <tr><td>oper</td> <td>a</td> <td> S </td> <td> Operator = </td> </tr>
 <tr><td>oper</td> <td>a</td> <td> t </td> <td> alignof of a type (C++11)</td> </tr>
+<tr><td>oper</td> <td>a</td> <td> w </td> <td> co_await (C++2a)</td> </tr>
 <tr><td>oper</td> <td>a</td> <td> z </td> <td> alignof of an expression (C++11) </td> </tr>
 <tr><td>type</td> <td>A</td> <td></td> <td> array type </td> </tr>
 <tr><td>type</td> <td>b</td> <td></td> <td> builtin type bool </td> </tr>

--- a/abi.html
+++ b/abi.html
@@ -4361,6 +4361,7 @@ the first of which is lowercase.
 		  ::= na	# new[]
 		  ::= dl	# delete        
 		  ::= da	# delete[]      
+		  ::= aw	# co_await      
 		  ::= ps        # + (unary)
 		  ::= ng	# - (unary)     
 		  ::= ad	# & (unary)     


### PR DESCRIPTION
This was proposed in cxx-abi-dev ([1](https://cxx-abi-dev.codesourcery.narkive.com/GGdYT1mo/coroutines-proposal-operator-co-await), [2](https://cxx-abi-dev.codesourcery.narkive.com/B4kGWkE0/operator-co-await)), has been used by Clang for years, and will likely be used by GCC ([relevant patch](https://gcc.gnu.org/ml/gcc-patches/2019-11/msg01611.html)).

Now coroutine has been merged into the draft standard, it seems to be time to add it to the ABI document.