### PR TITLE
Fix section number for `Transaction-Safe Function`

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -4581,7 +4581,7 @@ B &temp = b&lt;void&gt;;
 
 <p>
 <a name="mangling-transaction-safe">
-<h5><a href="#mangling-transaction-safe"> 5.1.4.5 Transaction-Safe Function
+<h5><a href="#mangling-transaction-safe"> 5.1.4.6 Transaction-Safe Function
 Entry Points</a></h5> A function declared transaction-safe or
 [[optimize_for_synchronized]] has two entry points: the normal function
 mangling, used for calls from a non-transaction context, and another entry


### PR DESCRIPTION
The section number is off by one.
I didn't see another PR for this, so if this is a duplicate please close. 