### PR TITLE
Extend grammar to allow parameterized vendor extension types.

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -4821,12 +4821,13 @@ Builtin types are represented by single-letter codes:
                  ::= Da # auto
                  ::= Dc # decltype(auto)
                  ::= Dn # std::nullptr_t (i.e., decltype(nullptr))
-		 ::= u &lt;<a href="#mangle.source-name">source-name</a>&gt;	# vendor extended type
+		 ::= u &lt;<a href="#mangle.source-name">source-name</a>&gt; [&lt;<a href="#mangle.template-args">template-args</a>&gt;] # vendor extended type
 </pre></font></code>
 
 <p>
 Vendors who define builtin extended types shall encode them
-as a 'u' prefix followed by the name in &lt;length,ID> form.
+as a 'u' prefix followed by the name in &lt;length,I&gt; form,
+followed by any arguments to the extended type.
 
 <a name="mangle.function-type">
 <h5><a href="#mangle.function-type">5.1.5.3 Function types</a></h5>


### PR DESCRIPTION
Allowing type parameters for vector extended types naturally allows
mangling of complex vendor extended types, like Clang's matrix type or
the various vector types.

This is in line with the grammarm for vendor extended qualifiers.

Fixes #100.