### PR TITLE
Refer to C++11 rather than C++0x

### DIFF
--- a/abi-mangling.html
+++ b/abi-mangling.html
@@ -56,10 +56,10 @@ C++ ABI for IA-64: Mangling
 <tr><td>oper</td> <td>d</td> <td> V </td> <td> Operator /= </td> </tr>
 <tr><td>syn </td> <td>d</td> <td> x </td> <td> Designated array initializer </td> </tr>
 <tr><td>syn </td> <td>d</td> <td> X </td> <td> Designated array range initializer </td> </tr>
-<tr><td>type</td> <td>D</td> <td> p </td> <td> pack expansion of (C++0x) </td> </tr>
-<tr><td>type</td> <td>D</td> <td> t </td> <td> decltype of an id-expression or class member access (C++0x) </td> </tr>
+<tr><td>type</td> <td>D</td> <td> p </td> <td> pack expansion of (C++11) </td> </tr>
+<tr><td>type</td> <td>D</td> <td> t </td> <td> decltype of an id-expression or class member access (C++11) </td> </tr>
 <tr><td>obj </td> <td>D</td> <td> C </td> <td> structured binding declaration (C++1z) </td> </tr>
-<tr><td>type</td> <td>D</td> <td> T </td> <td> decltype of an expression (C++0x) </td> </tr>
+<tr><td>type</td> <td>D</td> <td> T </td> <td> decltype of an expression (C++11) </td> </tr>
 <tr><td>obj </td> <td>D</td> <td> 0 </td> <td> Deleting destructor</td> </tr>
 <tr><td>obj </td> <td>D</td> <td> 1 </td> <td> Complete object (in-charge) destructor</td> </tr>
 <tr><td>obj </td> <td>D</td> <td> 2 </td> <td> Base object (not-in-charge) destructor</td> </tr>
@@ -107,7 +107,7 @@ C++ ABI for IA-64: Mangling
 <tr><td>oper</td> <td>o</td> <td> o </td> <td> Operator || </td> </tr>
 <tr><td>oper</td> <td>o</td> <td> r </td> <td> Operator | </td> </tr>
 <tr><td>oper</td> <td>o</td> <td> R </td> <td> Operator |= </td> </tr>
-<tr><td>type</td> <td>O</td> <td></td> <td> rvalue reference type (C++0x) </td> </tr>
+<tr><td>type</td> <td>O</td> <td></td> <td> rvalue reference type (C++11) </td> </tr>
 <tr><td>oper</td> <td>p</td> <td> l </td> <td> Operator + </td> </tr>
 <tr><td>oper</td> <td>p</td> <td> L </td> <td> Operator += </td> </tr>
 <tr><td>oper</td> <td>p</td> <td> m </td> <td> Operator ->* </td> </tr>

--- a/abi.html
+++ b/abi.html
@@ -4923,10 +4923,10 @@ substitution candidate.
 </p>
 
 <p>
-When a function parameter is a C++0x function parameter pack, its type
+When a function parameter is a C++11 function parameter pack, its type
 is mangled with <code>Dp &lt;<a href="#mangle.type">type</a>&gt;</code>, i.e., its type is a pack
 expansion:
-<pre><font color="blue"><code> &lt;<a name="mangle.type">type</a>&gt;  ::= Dp &lt;<a href="#mangle.type">type</a>&gt;          # pack expansion (C++0x)
+<pre><font color="blue"><code> &lt;<a name="mangle.type">type</a>&gt;  ::= Dp &lt;<a href="#mangle.type">type</a>&gt;          # pack expansion (C++11)
 </code></font></pre>
 </p>
 
@@ -4939,8 +4939,8 @@ either <code>Dt</code> or <code>DT</code>, depending on how
 the <code>decltype</code> type was parsed.  (See farther <a href=#expressions>below</a> for
 the encoding of expressions.)
 
-<pre><font color="blue"><code> &lt;decltype&gt;  ::= Dt &lt;<a href="#mangle.expression">expression</a>&gt; E  # decltype of an id-expression or class member access (C++0x)
-             ::= DT &lt;<a href="#mangle.expression">expression</a>&gt; E  # decltype of an expression (C++0x)
+<pre><font color="blue"><code> &lt;decltype&gt;  ::= Dt &lt;<a href="#mangle.expression">expression</a>&gt; E  # decltype of an id-expression or class member access (C++11)
+             ::= DT &lt;<a href="#mangle.expression">expression</a>&gt; E  # decltype of an expression (C++11)
 </code></font></pre>
 If the operand expression of <code>decltype</code> is not
 <a href=#instantiation-dependent>instantiation-dependent</a>
@@ -5403,7 +5403,7 @@ is used even if the indicated member is actually known.  Similarly,
 an <code>&lt;<a href="#mangle.unresolved-qualifier-level">unresolved-qualifier-level</a>&gt;</code> may encode a known
 class type.
 That production is also used for references to nonstatic members with no
-associated expression designating the enclosing object (a C++0x feature).
+associated expression designating the enclosing object (a C++11 feature).
 For example:
 <code><pre>          struct Q { int x; } q;
           template&lt;class T> auto f(T p)->decltype(p.x + q.x);


### PR DESCRIPTION
I just noticed that some parts of the text refer to C++0x whereas others say C++11. The latter seems better.