### PR TITLE
Add 'fpT' as encoding for the 'this' pointer

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -5109,6 +5109,7 @@ most common -- L can be zero).  For example:
 		   ::= fL &lt;L-1 non-negative <a href="#mangle.number">number</a>&gt; p &lt;<i>top-level</i> <a href="#mangle.CV-qualifiers">CV-qualifiers</a>&gt; _         # L > 0, first parameter
 		   ::= fL &lt;L-1 non-negative <a href="#mangle.number">number</a>&gt; p &lt;<i>top-level</i> <a href="#mangle.CV-qualifiers">CV-qualifiers</a>&gt;
                                                     &lt;<i>parameter-2 non-negative</i> <a href="#mangle.number">number</a>&gt; _   # L > 0, second and later parameters
+		   ::= fpT                                                                # this
 </font></code></pre>
 Note that top-level cv-qualifiers specified on a parameter type do not
 affect the function type directly (i.e., <code>int(*)(T)</code> and


### PR DESCRIPTION
For example, in

```c++
struct B { template<class> void f(); };

struct A {
    B b;
    template<class T>
    auto f() -> decltype(this->b.f<T>()) {}
};

template void A::f<int>();
```
`this->b` is mangled as `ptfpT1b`.

Tested GCC, Clang, and ICC: https://godbolt.org/z/Vdxn_5 .
