### PR TITLE
Add a note that constexpr functions are never key functions.

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -6027,6 +6027,8 @@ with the virtual table mangled name as the identifying symbol.
 Note that if the key function is not declared inline in the class definition,
 but its definition later is always declared inline,
 it will be emitted in every object containing the definition.</i>
+A constexpr or consteval function is always declared constexpr or consteval on
+its first declaration, and is implicitly inline, so is never a key function.
 
 <p>
 <img src=warning.gif alt="<b>NOTE</b>:">


### PR DESCRIPTION
This is a consequence of the existing wording, and makes sense for the same reason we don't want inline functions to be key functions in general, but is not universal implementation practice: GCC does not allow constexpr virtual functions to be key functions, but Clang 10 does.