### PR TITLE
Add a new mangling for vendor extended expressions which may take expression or type arguments.

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -5261,6 +5261,7 @@ For example:
                ::= fR &lt;<i>binary</i> <a href="#mangle.operator-name">operator-name</a>&gt; &lt;<a href="#mangle.expression">expression</a>&gt; &lt;<a href="#mangle.expression">expression</a>&gt;  # (expression operator ... operator expression), binary right fold
                ::= tw &lt;<a href="#mangle.expression">expression</a>&gt;                                      # throw expression
                ::= tr                                                   # throw with no operand (rethrow)
+               ::= u &lt;<a href="#mangle.source-name">source-name</a>&gt; &lt;<a href="#mangle.template-arg">template-arg</a>&gt;* E                    # vendor extended expression
                ::= &lt;<a href="#mangle.unresolved-name">unresolved-name</a>&gt;                                    # f(p), N::f(p), ::f(p),
                                                                         # freestanding dependent name (e.g., T::x),
                                                                         # objectless nonstatic member reference


### PR DESCRIPTION
This could be used, for example, to mangle GCC's `__alignof__(type-or-expression)` extension.

Fixes #112