### PR TITLE
Rename <data-member-prefix> to cover non-data member cases.

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -5870,11 +5870,10 @@ If the context of a closure type is an initializer for a class
 member (static or nonstatic), inline variable, or variable template,
 it is encoded in a qualified name with a
 <code>&lt;<a href="#mangle.prefix">prefix</a>&gt;</code> of the form:
-<code><pre><font color=blue>  &lt;closure-prefix&gt; ::= [ &lt;<a href="#mangle.prefix">prefix</a>&gt; ] &lt;<i>variable or member</i> <a href="#mangle.unqualified-name">unqualified-name</a>&gt; [&lt;<a href="#mangle.template-args">template-args</a>&gt;] M
+<code><pre><font color=blue>
+    &lt;closure-prefix&gt; ::= [ &lt;<a href="#mangle.prefix">prefix</a>&gt; ] &lt;<i>variable or member</i> <a href="#mangle.unqualified-name">unqualified-name</a>&gt; M
+                     ::= &lt;<i>variable template</i> <a href="#mangle.template-prefix">template-prefix</a>&gt; &lt;<a href="#mangle.template-args">template-args</a>&gt; M
 </font></pre></code>
-where the <code>&lt;<a href="#mangle.template-args">template-args</a>&gt;</code>
-is present for a closure type within a variable template specialization
-and absent otherwise.
 For example:
 <code><pre>
 	template&lt;typename T> struct S {

--- a/abi.html
+++ b/abi.html
@@ -4472,9 +4472,9 @@ qualifiers could be inferred from the substitution target.
     &lt;<a name="mangle.prefix">prefix</a>&gt; ::= &lt;<a href="#mangle.unqualified-name">unqualified-name</a>&gt;                 # global class or namespace
              ::= &lt;<a href="#mangle.prefix">prefix</a>&gt; &lt;<a href="#mangle.unqualified-name">unqualified-name</a>&gt;        # nested class or namespace
 	     ::= &lt;<a href="#mangle.template-prefix">template-prefix</a>&gt; &lt;<a href="#mangle.template-args">template-args</a>&gt;  # class template specialization
+             ::= &lt;<a href="#mangle.closure-prefix">closure-prefix</a>&gt;                   # initializer of a variable or data member
              ::= &lt;<a href="#mangle.template-param">template-param</a>&gt;                   # template type parameter
              ::= &lt;<a href="#mangle.decltype">decltype</a>&gt;                         # decltype qualifier
-             ::= &lt;<a href="#mangle.prefix">prefix</a>&gt; &lt;<a href="#mangle.data-member-prefix">data-member-prefix</a>&gt;      # initializer of a data member
 	     ::= &lt;<a href="#mangle.substitution">substitution</a>&gt;
 
     &lt;<a name="mangle.template-prefix">template-prefix</a>&gt; ::= &lt;<i>template</i> <a href="#mangle.unqualified-name">unqualified-name</a>&gt;           # global template
@@ -5865,12 +5865,12 @@ not affect its encoding.
 </pre></code>
 
 
-<a name="mangle.data-member-prefix"><p>
+<a name="mangle.closure-prefix"><p>
 If the context of a closure type is an initializer for a class
 member (static or nonstatic), inline variable, or variable template,
 it is encoded in a qualified name with a
-final <code>&lt;<a href="#mangle.prefix">prefix</a>&gt;</code> of the form:
-<code><pre><font color=blue>  &lt;data-member-prefix&gt; ::= &lt;<i>member</i> <a href="#mangle.source-name">source-name</a>&gt; [&lt;<a href="#mangle.template-args">template-args</a>&gt;] M
+<code>&lt;<a href="#mangle.prefix">prefix</a>&gt;</code> of the form:
+<code><pre><font color=blue>  &lt;closure-prefix&gt; ::= [ &lt;<a href="#mangle.prefix">prefix</a>&gt; ] &lt;<i>variable or member</i> <a href="#mangle.unqualified-name">unqualified-name</a>&gt; [&lt;<a href="#mangle.template-args">template-args</a>&gt;] M
 </font></pre></code>
 where the <code>&lt;<a href="#mangle.template-args">template-args</a>&gt;</code>
 is present for a closure type within a variable template specialization


### PR DESCRIPTION
Extend grammar to cover additional contexts where this can be used.

Fixes #94.