### PR TITLE
Add a mangling for the _BitInt datatype from C23.

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -5014,8 +5014,10 @@ Builtin types are represented by single-letter codes:
                  ::= Df # IEEE 754r decimal floating point (32 bits)
                  ::= Dh # IEEE 754r half-precision floating point (16 bits)
                  ::= DF &lt;<a href="#mangle.number">number</a>&gt; _ # ISO/IEC TS 18661 binary floating point type _FloatN (N bits)
-                 ::= DB &lt;<a href="#mangle.number">number</a>&gt; | &lt;<a href="#mangle.template-args">template-args</a>&gt; _  # C23 signed _BitInt(N)
-                 ::= DU &lt;<a href="#mangle.number">number</a>&gt; | &lt;<a href="#mangle.template-args">template-args</a>&gt; _  # C23 unsigned _BitInt(N)
+                 ::= DB &lt;<a href="#mangle.number">number</a>&gt; _        # C23 signed _BitInt(N)
+                 ::= DB &lt;<a href="#mangle.expression">expression</a>&gt; _ # C23 signed _BitInt(N)
+                 ::= DU &lt;<a href="#mangle.number">number</a>&gt; _        # C23 unsigned _BitInt(N)
+                 ::= DU &lt;<a href="#mangle.expression">expression</a>&gt; _ # C23 unsigned _BitInt(N)
                  ::= Di # char32_t
                  ::= Ds # char16_t
                  ::= Du # char8_t

--- a/abi.html
+++ b/abi.html
@@ -5014,6 +5014,10 @@ Builtin types are represented by single-letter codes:
                  ::= Df # IEEE 754r decimal floating point (32 bits)
                  ::= Dh # IEEE 754r half-precision floating point (16 bits)
                  ::= DF &lt;<a href="#mangle.number">number</a>&gt; _ # ISO/IEC TS 18661 binary floating point type _FloatN (N bits)
+                 ::= DB &lt;<a href="#mangle.number">number</a>&gt; _        # signed _BitInt(N)
+                 ::= DB &lt;<a href="#mangle.template-args">template-args</a>&gt; _ # signed _BitInt(N)
+                 ::= DU &lt;<a href="#mangle.number">number</a>&gt; _        # unsigned _BitInt(N)
+                 ::= DU &lt;<a href="#mangle.template-args">template-args</a>&gt; _ # unsigned _BitInt(N)
                  ::= Di # char32_t
                  ::= Ds # char16_t
                  ::= Du # char8_t

--- a/abi.html
+++ b/abi.html
@@ -5014,10 +5014,8 @@ Builtin types are represented by single-letter codes:
                  ::= Df # IEEE 754r decimal floating point (32 bits)
                  ::= Dh # IEEE 754r half-precision floating point (16 bits)
                  ::= DF &lt;<a href="#mangle.number">number</a>&gt; _ # ISO/IEC TS 18661 binary floating point type _FloatN (N bits)
-                 ::= DB &lt;<a href="#mangle.number">number</a>&gt; _        # signed _BitInt(N)
-                 ::= DB &lt;<a href="#mangle.template-args">template-args</a>&gt; _ # signed _BitInt(N)
-                 ::= DU &lt;<a href="#mangle.number">number</a>&gt; _        # unsigned _BitInt(N)
-                 ::= DU &lt;<a href="#mangle.template-args">template-args</a>&gt; _ # unsigned _BitInt(N)
+                 ::= DB &lt;<a href="#mangle.number">number</a>&gt; | &lt;<a href="#mangle.template-args">template-args</a>&gt; _  # C23 signed _BitInt(N)
+                 ::= DU &lt;<a href="#mangle.number">number</a>&gt; | &lt;<a href="#mangle.template-args">template-args</a>&gt; _  # C23 unsigned _BitInt(N)
                  ::= Di # char32_t
                  ::= Ds # char16_t
                  ::= Du # char8_t

--- a/abi.html
+++ b/abi.html
@@ -5015,9 +5015,9 @@ Builtin types are represented by single-letter codes:
                  ::= Dh # IEEE 754r half-precision floating point (16 bits)
                  ::= DF &lt;<a href="#mangle.number">number</a>&gt; _ # ISO/IEC TS 18661 binary floating point type _FloatN (N bits)
                  ::= DB &lt;<a href="#mangle.number">number</a>&gt; _        # C23 signed _BitInt(N)
-                 ::= DB &lt;<a href="#mangle.expression">expression</a>&gt; _ # C23 signed _BitInt(N)
+                 ::= DB &lt;<i>instantiation-dependent</i> <a href="#mangle.expression">expression</a>&gt; _ # C23 signed _BitInt(N)
                  ::= DU &lt;<a href="#mangle.number">number</a>&gt; _        # C23 unsigned _BitInt(N)
-                 ::= DU &lt;<a href="#mangle.expression">expression</a>&gt; _ # C23 unsigned _BitInt(N)
+                 ::= DU &lt;<i>instantiation-dependent</i> <a href="#mangle.expression">expression</a>&gt; _ # C23 unsigned _BitInt(N)
                  ::= Di # char32_t
                  ::= Ds # char16_t
                  ::= Du # char8_t


### PR DESCRIPTION
C23 adds a new builtin datatype named `_BitInt` for a family of bit-precise integer types that can be either signed or unsigned. This adds a proper mangling for the datatype for implementations that provide this feature as an extension in C++ and for implementations that support overloading within C as an extension. This implements #128.