### PR TITLE
Add mangling for _FloatNx and bfloat16_t

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -5127,7 +5127,7 @@ Builtin types are represented by single-letter codes:
                  ::= Dh # IEEE 754r half-precision floating point (16 bits)
                  ::= DF &lt;<a href="#mangle.number">number</a>&gt; _ # ISO/IEC TS 18661 binary floating point type _FloatN (N bits), C++23 std::floatN_t
                  ::= DF &lt;<a href="#mangle.number">number</a>&gt; x # IEEE extended precision formats, C23 _FloatNx (N bits)
-                 ::= DFb16_ # C++23 std::bfloat16_t
+                 ::= DF16b # C++23 std::bfloat16_t
                  ::= DB &lt;<a href="#mangle.number">number</a>&gt; _        # C23 signed _BitInt(N)
                  ::= DB &lt;<i>instantiation-dependent</i> <a href="#mangle.expression">expression</a>&gt; _ # C23 signed _BitInt(N)
                  ::= DU &lt;<a href="#mangle.number">number</a>&gt; _        # C23 unsigned _BitInt(N)

--- a/abi.html
+++ b/abi.html
@@ -5125,7 +5125,9 @@ Builtin types are represented by single-letter codes:
                  ::= De # IEEE 754r decimal floating point (128 bits)
                  ::= Df # IEEE 754r decimal floating point (32 bits)
                  ::= Dh # IEEE 754r half-precision floating point (16 bits)
-                 ::= DF &lt;<a href="#mangle.number">number</a>&gt; _ # ISO/IEC TS 18661 binary floating point type _FloatN (N bits)
+                 ::= DF &lt;<a href="#mangle.number">number</a>&gt; _ # ISO/IEC TS 18661 binary floating point type _FloatN (N bits), C++23 std::floatN_t
+                 ::= DFx &lt;<a href="#mangle.number">number</a>&gt; _ # IEEE extended precision formats, C23 _FloatNx (N bits)
+                 ::= DFb16_ # C++23 std::bfloat16_t
                  ::= DB &lt;<a href="#mangle.number">number</a>&gt; _        # C23 signed _BitInt(N)
                  ::= DB &lt;<i>instantiation-dependent</i> <a href="#mangle.expression">expression</a>&gt; _ # C23 signed _BitInt(N)
                  ::= DU &lt;<a href="#mangle.number">number</a>&gt; _        # C23 unsigned _BitInt(N)

--- a/abi.html
+++ b/abi.html
@@ -5126,7 +5126,7 @@ Builtin types are represented by single-letter codes:
                  ::= Df # IEEE 754r decimal floating point (32 bits)
                  ::= Dh # IEEE 754r half-precision floating point (16 bits)
                  ::= DF &lt;<a href="#mangle.number">number</a>&gt; _ # ISO/IEC TS 18661 binary floating point type _FloatN (N bits), C++23 std::floatN_t
-                 ::= DFx &lt;<a href="#mangle.number">number</a>&gt; _ # IEEE extended precision formats, C23 _FloatNx (N bits)
+                 ::= DF &lt;<a href="#mangle.number">number</a>&gt; x # IEEE extended precision formats, C23 _FloatNx (N bits)
                  ::= DFb16_ # C++23 std::bfloat16_t
                  ::= DB &lt;<a href="#mangle.number">number</a>&gt; _        # C23 signed _BitInt(N)
                  ::= DB &lt;<i>instantiation-dependent</i> <a href="#mangle.expression">expression</a>&gt; _ # C23 signed _BitInt(N)


### PR DESCRIPTION
The current mangling is missing entries for C23 _FloatNx and C++23 std::bfloat16_t; I propose adding another character after DF to indicate these variants.

There's also the related question about how we want to handle __float128 and __float80, and also __int64 and __int128, given the new model where the explicitly sized types are extended types rather than aliases for standard types of the same size.

My inclination is to change \_\_float128 to be another name for std::float128_t, and perhaps mangle std::float128_t as 'g' for compatibility with any existing code.  And change \_\_float80 to be another name for \_Float64x, mangled as DFx64_.  

Similarly, I'd treat __int64 as _BitInt(64), mangled as _DB64, and treat __int128 as _BitInt(128), still mangled as 'n'.

Thoughts?