### PR TITLE
Fix link to repository

### DIFF
--- a/cxx-abi-dev/index.html
+++ b/cxx-abi-dev/index.html
@@ -16,7 +16,7 @@ C++ ABI</a> originally took place on a mailing list called
 "cxx-abi-dev", as well as several offline meetings.  That mailing
 list is now defunct, and discussion and development now happens 
 on our
-<a href="https://https://github.com/itanium-cxx-abi/cxx-abi/issues">
+<a href="https://github.com/itanium-cxx-abi/cxx-abi/issues">
 GitHub repository</a>.  However, the old discussions are still
 valuable as a source of historical information about the ABI,
 which can illuminate the intent of both the document and its


### PR DESCRIPTION
Minor fix, so that the repo url points to the right location.