### PR TITLE
Make _FloatN and _BitInt types as substitution candidates in mangling

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -6164,7 +6164,9 @@ and a candidate for being substituted.
 There are two exceptions that appear to be substitution
 candidates from the grammar, but are explicitly excluded:
 <ul>
-<li> &lt;<a href="#mangle.builtin-type">builtin-type</a>&gt; other than vendor extended types, and
+<li> &lt;<a href="#mangle.builtin-type">builtin-type</a>&gt; other than ISO/IEC
+    TS 18661 binary floating point _FloatN types, C23 _BitInt types, and vendor
+    extended types, and
 <li> function and operator names other than extern "C" functions.
 </ul>
 


### PR DESCRIPTION
As discussed in https://reviews.llvm.org/D140359, encodings of _FloatN and _BitInt(N) are relatively long, and thus should be treated as substitution candidates to shorten mangled names.