### PR TITLE
Clarify that the "type conflict" rule ignores cv-qualifiers

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -1045,8 +1045,8 @@ order), allocate as follows:
 	to nvalign(D) for base classes or
 	to align(D) for data members.
 	Place D at this offset unless doing so would result in two
-	components (direct or indirect) of the same type having the
-	same offset.
+	components (direct or indirect) of the same type (ignoring
+	cv-qualifiers) having the same offset.
 	If such a component type conflict occurs,
 	increment the candidate offset by nvalign(D)
 	for base classes or by align(D) for data members


### PR DESCRIPTION
GCC and Clang have divergent implementations of `[[no_unique_address]]` due to not ignoring cv-qualifiers in this check. The standard is being amended to say that cv-qualifiers should be ignored. Do the same in the corresponding ABI rule.