### PR TITLE
Explain the "early version" that disallowed reusing tail padding of POD

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -693,9 +693,10 @@ exactly like the pointer type <code>T *</code>.</li>
 The <i>dsize</i>, <i>nvsize</i>, and <i>nvalign</i> of these types are
 defined to be their ordinary size and alignment.  These properties
 only matter for non-empty class types that are used as base classes.
-We ignore tail padding for PODs because an early version of the
-standard did not allow us to use it for anything else and because it
-sometimes permits faster copying of the type.
+We ignore tail padding for PODs because the standard before the resolution
+of <a href="https://wg21.link/cwg43">CWG issue 43</a> did not allow us to use
+it for anything else and because it sometimes permits faster copying of the
+type.
 </p>
 
 <p> <hr> <p>


### PR DESCRIPTION
Such resuing is allowed by [CWG43](https://wg21.link/cwg43), although Itanium ABI is still ignoring it.