### PR TITLE
Fix weird format after one `inline`

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -6494,7 +6494,7 @@ emitted separately, and unreferenced tables can be omitted.
 The key function is the first non-pure virtual function that is
 not inline at the point of class definition.  <code>constexpr</code>
 or <code>consteval</code> functions are always declared as such on
-their first declarations and so are implicitly <code>inline</fixed>,
+their first declarations and so are implicitly <code>inline</code>,
 so they are never key functions.
 
 <p>


### PR DESCRIPTION
Currently, the format in abi.html is weird after "`constexpr` or `consteval` functions are always declared as such on their first declarations and so are implicitly `inline`", because #171 used an unknown tag `</fixed>`.

Presumably the tag should be `</code>`.