### PR TITLE
Escape angle brackets

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -781,7 +781,7 @@ data member must be involved.  For example:
 
     // The offset in D of the B3 base subobject is 2, but the
     // offset of the data member b is 1.
-    auto mptr = static_cast<char B3::*>(&D::b);
+    auto mptr = static_cast&lt;char B3::*&gt;(&D::b);
 </pre>
 
 <a name="member-function-pointers"></a>


### PR DESCRIPTION
Unescaped angle bracket pairs are interpreted as an HTML tag.