### PR TITLE
Add missing grammar rule for `<float>`

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -5763,6 +5763,10 @@ hexadecimal string corresponding to the internal representation,
 high-order bytes first.  For example: "Lf bf800000 E" is -1.0f on
 platforms conforming to IEEE 754.
 
+<a name="mangle.float">
+<pre><font color=blue><code>  &lt;float&gt; ::= &lt;<i>0-9a-f</i>&gt;+
+</pre></code></font>
+
 <p>
 The encoding for a literal of an enumerated type is the encoding of the
 type name followed by the encoding of the numeric value of the literal


### PR DESCRIPTION
This is referenced in a couple of places but never defined in the mangled name grammar.