### PR TITLE
Add missing HTML </dd> tags

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -134,6 +134,7 @@ The descriptions below make use of the following definitions:
 <dd>
 A value A such that any object X of type T has an address satisfying
 the constraint that &X modulo A == 0.
+</dd>
 
 <p>
 <dt> <i>base class</i> of a class T</dt>
@@ -144,12 +145,14 @@ it means T itself as well as all of the classes from which it is derived,
 directly or indirectly, virtually or non-virtually.
 We use the term&nbsp; <i>proper base class</i>
 to exclude T itself from the list.
+</dd>
 
 <p>
 <dt> <i>base object destructor</i> of a class T</dt>
 <dd>
 A function that runs the destructors for non-static data members of T and
 non-virtual direct base classes of T.
+</dd>
 
 <p>
 <dt> <i>basic ABI properties</i> of a type T</dt>
@@ -157,12 +160,14 @@ non-virtual direct base classes of T.
 The basic representational properties of a type decided by the base C ABI,
 including its size, its alignment, its treatment by calling conventions,
 and the representation of pointers to it.
+</dd>
 
 <p>
 <dt> <i>complete object destructor</i> of a class T</dt>
 <dd>
 A function that, in addition to the actions required of a base
 object destructor, runs the destructors for the virtual base classes of T.
+</dd>
 
 <p>
 <dt> <i>deleting destructor</i> of a class T</dt>
@@ -170,12 +175,14 @@ object destructor, runs the destructors for the virtual base classes of T.
 A function that, in addition to the actions required of a complete
 object destructor, calls the appropriate deallocation function
 (i.e,. <code>operator delete</code>) for T.
+</dd>
 
 <p>
 <dt> <i>direct base class order</i> </dt>
 <dd>
 When the direct base classes of a class are viewed as an ordered set,
 the order assumed is the order declared, left-to-right.
+</dd>
 
 <p>
 <dt> <i>diamond-shaped inheritance</i> </dt>
@@ -183,6 +190,7 @@ the order assumed is the order declared, left-to-right.
 A class has diamond-shaped inheritance iff it has a virtual base class
 that can be reached by distinct inheritance graph paths through
 more than one direct base.
+</dd>
 
 <p>
 <dt> <i>dynamic class</i> </dt>
@@ -190,6 +198,7 @@ more than one direct base.
 A class requiring a virtual table pointer
 (because it or its bases have one or more virtual member functions or
 virtual base classes).
+</dd>
 
 <p>
 <dt> <i>empty class</i> </dt>
@@ -198,17 +207,20 @@ A class with no non-static data members other than empty data members,
 no unnamed bit-fields other than zero-width bit-fields,
 no virtual functions, no virtual base classes,
 and no non-empty non-virtual proper base classes.
+</dd>
 
 <p>
 <dt> <i>empty data member</i> </dt>
 <dd>
 A potentially-overlapping non-static data member of empty class type.
+</dd>
 
 <p>
 <dt> <i>inheritance graph</i> </dt>
 <dd>
 A graph with nodes representing a class and all of its subobjects,
 and arcs connecting each node with its direct bases.
+</dd>
 
 <p>
 <dt> <i>inheritance graph order</i> </dt>
@@ -238,6 +250,7 @@ and then C and its subobjects.)
 Note that the traversal may be preorder or postorder.
 Unless otherwise specified,
 preorder (derived classes before their bases) is intended.
+</dd>
 
 <p>
 <a name="instantiation-dependent"></a>
@@ -254,6 +267,7 @@ Similarly, a type expressed in source code is <i>instantiation-dependent</i> if 
 form includes an <i>instantiation-dependent</i> expression.  For example, the type form
 <code>double[sizeof(sizeof(p))]</code> (with <code>p</code> a type dependent identifier)
 is instantiation-dependent.
+</dd>
 
 <p>
 <dt> <i>morally virtual</i> </dt>
@@ -261,6 +275,7 @@ is instantiation-dependent.
 A subobject X is a <i>morally virtual</i> base of Y if X is either a
 virtual base of Y, or the direct or indirect base of a virtual base of
 Y.
+</dd>
 
 <p>
 <dt> <i>nearly empty class</i> </dt>
@@ -277,6 +292,7 @@ A class that contains a virtual pointer, but no other data except
 </ul>
 Such classes may be primary base classes even if virtual,
 sharing a virtual pointer with the derived class.
+</dd>
 
 <p>
 <a name="non-trivial">
@@ -350,17 +366,20 @@ not have been POD in C++98.  This ABI is in compliance with that.
 <dd>
 A base class subobject or a non-static data member declared with
 the <tt>[[no_unique_address]]</tt> attribute.
+</dd>
 
 <p>
 <dt> <i>primary base class</i> </dt> <dd> For a dynamic class, the
 unique base class (if any) with which it shares the virtual pointer at
 offset 0.
+</dd>
 
 <p>
 <dt> <i>secondary virtual table</i> </dt>
 <dd>
 The instance of a virtual table for a base class
 that is embedded in the virtual table of a class derived from it.
+</dd>
 
 <p>
 <dt> <i>templated entity</i></dt>
@@ -375,6 +394,7 @@ An entity that is defined or created within a template, such as:
 <li>a local entity in a templated function; or
 <li>a lambda in a templated entity.
 </ul>
+</dd>
 
 <p>
 <dt> <i>thunk</i> </dt>
@@ -389,6 +409,7 @@ A thunk may contain as little as an instruction to be executed prior to
 falling through to an immediately following target function,
 or it may be a full function with its own stack frame that does
 a full call to the target function.
+</dd>
 
 <p>
 <dt> <i>vague linkage</i> </dt>
@@ -399,6 +420,7 @@ with external linkage that can be
 defined in multiple translation units,
 while the ODR requires that the program
 behave as if there were only a single definition.
+</dd>
 
 <p>
 <dt> <i>virtual table</i> (or <i>vtable</i>) </dt>
@@ -407,12 +429,14 @@ A dynamic class has an associated table
 (often several instances, but not one per object)
 which contains information about its dynamic attributes,
 e.g. virtual function pointers, virtual base class offsets, etc.
+</dd>
 
 <p>
 <dt> <i>virtual table group</i> </dt>
 <dd>
 The primary virtual table for a class along with all of the associated
 secondary virtual tables for its proper base classes.
+</dd>
 
 </dl>
 


### PR DESCRIPTION
The document is weirdly indented by w3m's renderer. Fix that by explicitly closing all `<dd>` tags.