### PR TITLE
Fix typo in abi.html: xpression => expression.

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -4559,7 +4559,7 @@ to the same value.  Mangling a non-dependent expression using
 its expression structure could incorrectly produce different
 manglings for different expressions that resolve to the same
 value, and it could incorrectly produce the same mangling for
-xpressions that resolve to different values but happen to be
+expressions that resolve to different values but happen to be
 spelled the same.
 
 <p>


### PR DESCRIPTION
Typo noticed will reading https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling.dependent.

Please apply when you can.

Thanks, Simon