### PR TITLE
Add mangling for pack indexing types and expressions (C++26)

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -5334,6 +5334,13 @@ expansion:
 </code></font></pre>
 </p>
 
+<p>
+A C++26 pack indexing type is mangled with :
+
+<pre><font color="blue"><code> &lt;<a name="mangle.type">type</a>&gt; ::= Dy &lt;<a href="#mangle.type">type</a>&gt; &lt;<a href="#mangle.expression">expression</a>&gt; # pack indexing (C++26)
+</code></font></pre>
+</p>
+
 <a name="mangle.decltype">
 <h5><a href="#mangle.decltype">5.1.5.4 C++11 <code>decltype</code></a></h5>
 
@@ -5704,6 +5711,8 @@ For example:
                ::= sZ &lt;<a href="#mangle.template-param">template-param</a>&gt;                                  # sizeof...(T), size of a template parameter pack
                ::= sZ &lt;<a href="#mangle.function-param">function-param</a>&gt;                                  # sizeof...(parameter), size of a function parameter pack
                ::= sP &lt;<a href="#mangle.template-arg">template-arg</a>&gt;* E                                 # sizeof...(T), size of a captured template parameter pack from an alias template
+               ::= sy &lt;<a href="#mangle.template-param">template-param</a>&gt;&lt;<a href="#mangle.expression">expression</a>&gt; # T...[expression], template parameter pack indexing
+               ::= sy &lt;<a href="#mangle.function-param">function-param</a>&gt; &lt;<a href="#mangle.expression">expression</a>&gt;                     # T...[expression], function parameter pack indexing
                ::= sp &lt;<a href="#mangle.expression">expression</a>&gt;                                      # expression..., pack expansion
                ::= fl &lt;<i>binary</i> <a href="#mangle.operator-name">operator-name</a>&gt; &lt;<a href="#mangle.expression">expression</a>&gt;               # (... operator expression), unary left fold
                ::= fr &lt;<i>binary</i> <a href="#mangle.operator-name">operator-name</a>&gt; &lt;<a href="#mangle.expression">expression</a>&gt;               # (expression operator ...), unary right fold


### PR DESCRIPTION
This proposes
```
<type> ::= Dy <type> <index expression>                   # pack indexing type
<expression> ::= sy <template-param> <index expression>   # pack indexing expression
<expression> ::= sy <function-param> <index expression>   # pack indexing expression
```

And roughly mirrors `sizeof...`.
The case of a partially substituted pack of type is not handled.