### PR TITLE
Allow '$' in identifiers

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -4480,10 +4480,11 @@ we use <code>Ret?</code> for an unknown function return type
 or <code>Type?</code> for an unknown data type.
 
 <p>
-Mangled names containing <code class=mangle>$</code> or
-<code class=mangle>.</code> are reserved for private implementation
-use. Names produced using such extensions are inherently non-portable
-and should be given internal linkage where possible.
+Mangled names containing <code class=mangle>$</code> in non-terminals
+other than <a href="#mangle.identifier">identifier</a> and mangled
+names containing <code class=mangle>.</code> are reserved for private
+implementation use. Names produced using such extensions are inherently
+non-portable and should be given internal linkage where possible.
 
 <p>
 <a name="mangling-structure">
@@ -4719,7 +4720,7 @@ qualifiers could be inferred from the substitution target.
 </pre></code></font>
 
 <p>
-&lt;<a href="#mangle.identifier">identifier</a>&gt; is a pseudo-terminal representing the characters in the unqualified identifier for the entity in the source code.  This ABI does not yet specify a mangling for identifiers containing characters outside of <code>_A-Za-z0-9</code>.
+&lt;<a href="#mangle.identifier">identifier</a>&gt; is a pseudo-terminal representing the characters in the unqualified identifier for the entity in the source code.  This ABI does not yet specify a mangling for identifiers containing characters outside of <code>$_A-Za-z0-9</code>.
 
 <p>
 Note that &lt;<a href="#mangle.source-name">source-name</a>&gt; in the productions for &lt;<a href="#mangle.unqualified-name">unqualified-name</a>&gt;


### PR DESCRIPTION
WG21 recently started discussing [P4234 ($identifiers)](https://wg21.link/p4234); a proposal that seeks to standardize support for `$` characters in identifiers in some form.

Clang, GCC, ICX, AOCC, NVC++, and MSVC all allow the `$` character to appear in identifiers in their default compilation modes as a C and C++ extension. Clang, GCC, ICX, and AOCC allow the extension to be disabled via the `-fno-dollars-in-identifiers` option. MSVC only allows it to be disabled by disabling all extensions with the `/Za` option. EDG doesn't have a default compilation mode per se, but EDG-based compilers can enable EDG's `--dollar` option by default.

All of the above compilers except for MSVC use IA64 mangling, and all them appear to mangle identifiers that contain `$` characters in the same way.

This PR adds `$` to the set of characters allowed in identifiers and clarifies the wording for the existing use of `$` as a vendor extension to only apply when used outside the `<identifier>` non-terminal. This update is intended to acknowledge existing practice.